### PR TITLE
Handle response

### DIFF
--- a/lib/SeatsIo/SeatsIo.php
+++ b/lib/SeatsIo/SeatsIo.php
@@ -371,7 +371,7 @@ class SeatsIo
             }
         }
 
-        $jsonDecoded = json_decode($content);
+        $jsonDecoded = json_decode($content, true);
         if (json_last_error() == JSON_ERROR_NONE) {
             return $jsonDecoded;
         } else {


### PR DESCRIPTION
son_decode() braucht den zweiten Parameter, sonst wird statt eines arrays ein StdObject erzeugt.